### PR TITLE
Clean CI 

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,19 +16,12 @@ jobs:
         working-directory: .
     steps:
       - uses: actions/checkout@v4
-      - uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_KEY_POOL }}
       - name: Check all tests
         run: cargo test
       - name: Clippy with features
         run: cargo clippy --all-targets --all-features -- -D warnings
-      - name: Install Nightly
-        run: rustup toolchain install nightly
-      - name: Add nightly toolchain for rustfmt
-        run: rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
       - name: Check format
-        run: cargo +nightly fmt --verbose --all -- --check
+        run: cargo fmt --verbose --all -- --check
       - name: Install llvm-cov tool for cargo
         run: cargo +stable install cargo-llvm-cov --locked
       - name: Code coverage

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,3 @@
-ignore = ["**/out/bindings/**"]
 # Format comments
 comment_width = 100
 wrap_comments = true


### PR DESCRIPTION
Now code and so CI don't depend on PufferPool and Rave contracts repos anymore, we can remove some steps.