### PR TITLE
Update Docker Hub repo's name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,4 +88,4 @@ jobs:
             context: .
             file: ./docker/Dockerfile
             push: true
-            tags: pufferfi/coral:${{ github.event.inputs.version }}
+            tags: pufferfi/coral-cli:${{ github.event.inputs.version }}


### PR DESCRIPTION
- Update Docker Hub repo's name from `coral` to  `coral-cli`