### PR TITLE
Refactor `sign-vem` output file content 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ cargo build --release
 cargo run --bin coral-cli
 ```
 
-## Installing
+## Installing coral-cli
+
+### Inside this repository
 ```
 cargo install -f --path=coral-cli
+```
+
+### Remote installation without local repository cloning
+
+```
+cargo install -f --git https://github.com/PufferFinance/coral.git
 ```

--- a/coral-cli/docs/validator.md
+++ b/coral-cli/docs/validator.md
@@ -50,7 +50,7 @@ coral-cli validator keygen \
 
 ## `validator sign-voluntary-exit`
 Generate signature needed to broadcast a voluntary exit message.
-(To be used with a beacon client)
+(To be used with a beacon client or on broadcast Beaconcha.in's tool)
 
 ```
 coral-cli validator sign-voluntary-exit \

--- a/coral-cli/docs/validator.md
+++ b/coral-cli/docs/validator.md
@@ -50,16 +50,19 @@ coral-cli validator keygen \
 
 ## `validator sign-voluntary-exit`
 Generate signature needed to broadcast a voluntary exit message.
-(To be used with a beacon client or on broadcast Beaconcha.in's tool)
+
+To be used with a beacon client or with broadcast Beaconcha.in's tool: 
+For holesky: https://holesky.beaconcha.in/tools/broadcast
+For mainnet: https://beaconcha.in/tools/broadcast
 
 ```
 coral-cli validator sign-voluntary-exit \
-  --bls-public-key 0x94505f60bb8e48ddafb8835ec08537c48ed1bb9bc6a95fe941f37869b5eb0950c9023b7a997fe12d8aa79076561e009f \
-  --beacon-index 1605300 \
-  --enclave-url http://localhost:9001 \
-  --fork-previous-version 0x04017000 \
-  --fork-current-version 0x05017000 \
-  --epoch 29696 \
+  --bls-public-key 0x97cbe16970f7045cf4bf4e9bc6d3a2ae8edaba9a44308610ba4289b2da0ddb19cb4e190b455628f7e1ce8729f8d04f30 \
+  --beacon-index 1695171 \
+  --enclave-url http://localhost:9002 \
+  --fork-current-version 0x04017000 \
+  --fork-previous-version 0x03017000 \
+  --epoch 256 \
   --genesis-validators-root 0x9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1 \
   --output-file sign_vem_001.json
 ```

--- a/coral-cli/src/commands/validator/sign_vem.rs
+++ b/coral-cli/src/commands/validator/sign_vem.rs
@@ -8,14 +8,6 @@ use puffersecuresigner::strip_0x_prefix;
 use serde::{Deserialize, Serialize};
 use std::io::Write;
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct ExitResponseOutput {
-    pub signature: String,
-    pub beacon_index: u64,
-    pub epoch: u64,
-    pub bls_pubkey: String,
-}
-
 #[derive(Clone, Debug)]
 pub struct SignVoluntaryExitMessageInput {
     pub bls_pubkey: String,
@@ -24,6 +16,18 @@ pub struct SignVoluntaryExitMessageInput {
     pub fork: Fork,
     pub genesis_validators_root: [u8; 32],
     pub output_file: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ExitResponseOutput {
+    pub message: VoluntaryExitMessage,
+    pub signature: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct VoluntaryExitMessage {
+    epoch: u64,
+    validator_index: u64,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -104,12 +108,13 @@ pub async fn sign_voluntary_exit_message(
             )
         })?;
 
-    let epoch = fork_info.clone().fork.epoch;
+    let message = VoluntaryExitMessage {
+        epoch: fork_info.clone().fork.epoch,
+        validator_index: input_data.beacon_index,
+    };
     let exit_payload = ExitResponseOutput {
         signature: sign_exit_resp.signature,
-        beacon_index: input_data.beacon_index,
-        epoch,
-        bls_pubkey: input_data.bls_pubkey,
+        message,
     };
 
     let json_string_pretty = serde_json::to_string_pretty(&exit_payload)?;

--- a/coral-cli/src/commands/validator/sign_vem.rs
+++ b/coral-cli/src/commands/validator/sign_vem.rs
@@ -26,8 +26,8 @@ pub struct ExitResponseOutput {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct VoluntaryExitMessage {
-    epoch: u64,
-    validator_index: u64,
+    epoch: String,
+    validator_index: String,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -109,8 +109,8 @@ pub async fn sign_voluntary_exit_message(
         })?;
 
     let message = VoluntaryExitMessage {
-        epoch: fork_info.clone().fork.epoch,
-        validator_index: input_data.beacon_index,
+        epoch: fork_info.clone().fork.epoch.to_string(),
+        validator_index: input_data.beacon_index.to_string(),
     };
     let exit_payload = ExitResponseOutput {
         signature: sign_exit_resp.signature,


### PR DESCRIPTION
To match https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolVoluntaryExit request body, `sign-vem` command output was changed