### PR TITLE
feat: add command `verify-merkle-tree-rewards` to verify merkle tree  of rewards data file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,9 +538,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "fca2be1d5c43812bae364ee3f30b3afcb7877cf59f4aeb94c66f313a41d2fac9"
 dependencies = [
  "serde",
 ]
@@ -600,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
 dependencies = [
  "jobserver",
  "libc",
@@ -2723,18 +2723,18 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -3131,9 +3131,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -3914,11 +3917,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -4383,9 +4387,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.1"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4471,21 +4475,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c"
+checksum = "7a44eede9b727419af8095cb2d72fab15487a541f54647ad4414b34096ee4631"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.17",
+ "toml_edit 0.22.18",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
@@ -4514,9 +4518,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.17"
+version = "0.22.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16"
+checksum = "1490595c74d930da779e944f5ba2ecdf538af67df1a9848cbd156af43c1b7cf0"
 dependencies = [
  "indexmap",
  "serde",
@@ -5155,6 +5159,27 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,9 +149,9 @@ checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii-canvas"
@@ -164,7 +170,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -192,7 +198,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -315,7 +321,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -350,7 +356,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -568,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -600,12 +606,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.7"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -635,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.13"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -645,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.13"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -657,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.12"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8670053e87c316345e384ca1f3eba3006fc6355ed8b8a1140d104e109e3df34"
+checksum = "6d7db6eca8c205649e8d3ccd05aa5042b1800a784e56bc7c43524fde8abbfa9b"
 dependencies = [
  "clap",
 ]
@@ -673,7 +680,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -811,7 +818,7 @@ dependencies = [
  "ethers",
  "hex",
  "puffersecuresigner",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "serde",
  "serde_json",
  "tokio",
@@ -831,15 +838,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -855,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 
 [[package]]
 name = "crossbeam-deque"
@@ -1010,7 +1017,7 @@ checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1078,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "dunce"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
@@ -1449,7 +1456,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.72",
+ "syn 2.0.76",
  "toml",
  "walkdir",
 ]
@@ -1467,7 +1474,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1493,7 +1500,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.72",
+ "syn 2.0.76",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -1643,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "ff"
@@ -1700,12 +1707,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -1826,7 +1833,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2011,6 +2018,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -2237,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2335,9 +2348,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -2369,11 +2382,11 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -2410,9 +2423,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2492,9 +2505,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libm"
@@ -2626,12 +2639,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.0.1"
+name = "miniz_oxide"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "hermit-abi",
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -2717,7 +2739,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -2736,17 +2758,17 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.2"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -2815,7 +2837,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2903,7 +2925,7 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3036,7 +3058,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3074,7 +3096,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3131,9 +3153,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
 ]
@@ -3146,12 +3168,12 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3193,11 +3215,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit 0.22.20",
 ]
 
 [[package]]
@@ -3267,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -3277,6 +3299,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.12",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -3284,9 +3307,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
 dependencies = [
  "bytes",
  "rand",
@@ -3308,14 +3331,15 @@ dependencies = [
  "libc",
  "once_cell",
  "socket2",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -3418,9 +3442,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
@@ -3429,9 +3453,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3497,14 +3521,14 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.25.4",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3525,7 +3549,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.12",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile 2.1.3",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3539,7 +3563,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.26.3",
- "winreg 0.52.0",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3631,9 +3655,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc-hex"
@@ -3643,18 +3667,18 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3684,7 +3708,7 @@ dependencies = [
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki 0.102.6",
+ "rustls-webpki 0.102.7",
  "subtle",
  "zeroize",
 ]
@@ -3700,9 +3724,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
  "base64 0.22.1",
  "rustls-pki-types",
@@ -3710,9 +3734,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
@@ -3726,9 +3750,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
@@ -3783,7 +3807,7 @@ version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3886,9 +3910,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -3906,20 +3930,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
  "memchr",
@@ -4011,6 +4035,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4169,7 +4199,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -4211,9 +4241,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4231,6 +4261,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "system-configuration"
@@ -4261,14 +4294,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4308,7 +4342,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -4387,9 +4421,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4411,7 +4445,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -4507,17 +4541,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
@@ -4547,15 +4570,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -4577,7 +4600,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -4719,9 +4742,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
 
 [[package]]
 name = "universal-hash"
@@ -4823,34 +4846,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4860,9 +4884,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4870,28 +4894,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4930,11 +4954,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4942,6 +4966,36 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -4957,6 +5011,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -5111,16 +5174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ws_stream_wasm"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5162,9 +5215,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.6.6"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -5172,13 +5225,13 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.6.6"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -5198,7 +5251,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -5242,9 +5295,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.12+zstd.1.5.6"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/coral-cli/Cargo.toml
+++ b/coral-cli/Cargo.toml
@@ -13,12 +13,12 @@ clap = { version = "4.5.11", features = ["derive"] }
 clap_complete = "4.5.11"
 colored = "2.1.0"
 ecies = { version = "0.2.7", default-features = false, features = ["pure"] }
+ethers = { version = "2.0.14" }
 hex = "0.4.3"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 tokio = { version = "1.39.1" }
 
-ethers = { version = "2.0.14", optional = true }
 
 # Puffer dependencies
 
@@ -27,4 +27,4 @@ puffersecuresigner = { git ="https://github.com/PufferFinance/secure-signer.git"
 
 [features]
 default = []
-dev = [ "ethers", "coral-lib/dev" ]
+dev = ["coral-lib/dev"]

--- a/coral-cli/docs/validator.md
+++ b/coral-cli/docs/validator.md
@@ -51,7 +51,7 @@ coral-cli validator keygen \
 ## `validator sign-voluntary-exit`
 Generate signature needed to broadcast a voluntary exit message.
 
-To be used with a beacon client or with broadcast Beaconcha.in's tool: 
+To be used with a beacon client or with broadcast `beaconcha.in`'s tool: 
 For holesky: https://holesky.beaconcha.in/tools/broadcast
 For mainnet: https://beaconcha.in/tools/broadcast
 
@@ -65,4 +65,11 @@ coral-cli validator sign-voluntary-exit \
   --epoch 256 \
   --genesis-validators-root 0x9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1 \
   --output-file sign_vem_001.json
+```
+
+## `validator verify-merkle-tree-rewards`
+From an input file containing partial withdrawals data between 2 epochs, this command generates the merkle tree root and proofs and compares it from the given merkle root.
+
+```
+coral-cli validator verify-merkle-tree-rewards --rewards-file ./coral-cli/src/tests/rewards-files/rewards-test-1.json
 ```

--- a/coral-cli/docs/validator.md
+++ b/coral-cli/docs/validator.md
@@ -72,4 +72,5 @@ From an input file containing partial withdrawals data between 2 epochs, this co
 
 ```
 coral-cli validator verify-merkle-tree-rewards --rewards-file ./coral-cli/src/tests/rewards-files/rewards-test-1.json
+--rpc-url https://ethereum-sepolia-rpc.publicnode.com
 ```

--- a/coral-cli/docs/validator.md
+++ b/coral-cli/docs/validator.md
@@ -71,6 +71,5 @@ coral-cli validator sign-voluntary-exit \
 From an input file containing partial withdrawals data between 2 epochs, this command generates the merkle tree root and proofs and compares it from the given merkle root.
 
 ```
-coral-cli validator verify-merkle-tree-rewards --rewards-file ./coral-cli/src/tests/rewards-files/rewards-test-1.json
---rpc-url https://ethereum-sepolia-rpc.publicnode.com
+coral-cli validator verify-merkle-tree-rewards --rewards-file ./coral-cli/src/tests/rewards-files/rewards-test-1.json --rpc-url https://ethereum-sepolia-rpc.publicnode.com
 ```

--- a/coral-cli/src/commands/validator/keygen.rs
+++ b/coral-cli/src/commands/validator/keygen.rs
@@ -90,10 +90,10 @@ pub async fn keygen_from_cmd(data: KeygenCmdInput) -> AppResult<i32> {
     let password = match password_file {
         None => None,
         Some(path) => {
-            let password = std::fs::read_to_string(path).map_err(|err| {
+            let password = std::fs::read_to_string(path).inspect_err(|err| {
                 let error_msg = "Failed to read password file";
                 eprintln!("{}", error_msg.red());
-                err
+                eprintln!("Error details: {}", err);
             })?;
             Some(password.trim().to_string())
         }

--- a/coral-cli/src/commands/validator/mod.rs
+++ b/coral-cli/src/commands/validator/mod.rs
@@ -1,6 +1,7 @@
 pub mod keygen;
 pub mod list_keys;
 pub mod sign_vem;
+pub mod verify_merkle_tree_rewards;
 
 #[cfg(feature = "dev")]
 pub mod register_calldata;
@@ -109,6 +110,10 @@ pub enum ValidatorCommand {
         #[arg(long = "module-address")]
         module_address: String,
     },
+    VerifyMerkleTreeRewards {
+        #[arg(long = "rewards-file")]
+        rewards_file: String,
+    },
 }
 
 impl ValidatorCommand {
@@ -177,6 +182,9 @@ impl ValidatorCommand {
                     output_file,
                 )
                 .await?;
+            }
+            Self::VerifyMerkleTreeRewards { rewards_file } => {
+                verify_merkle_tree_rewards::verify_merkle_tree_rewards(rewards_file).await?;
             }
             #[cfg(feature = "dev")]
             Self::RegisterKey {

--- a/coral-cli/src/commands/validator/mod.rs
+++ b/coral-cli/src/commands/validator/mod.rs
@@ -185,8 +185,12 @@ impl ValidatorCommand {
                 )
                 .await?;
             }
-            Self::VerifyMerkleTreeRewards { rewards_file, rpc_url } => {
-                verify_merkle_tree_rewards::verify_merkle_tree_rewards(rewards_file, rpc_url).await?;
+            Self::VerifyMerkleTreeRewards {
+                rewards_file,
+                rpc_url,
+            } => {
+                verify_merkle_tree_rewards::verify_merkle_tree_rewards(rewards_file, rpc_url)
+                    .await?;
             }
             #[cfg(feature = "dev")]
             Self::RegisterKey {

--- a/coral-cli/src/commands/validator/mod.rs
+++ b/coral-cli/src/commands/validator/mod.rs
@@ -113,6 +113,8 @@ pub enum ValidatorCommand {
     VerifyMerkleTreeRewards {
         #[arg(long = "rewards-file")]
         rewards_file: String,
+        #[arg(long = "rpc-url")]
+        rpc_url: String,
     },
 }
 
@@ -183,8 +185,8 @@ impl ValidatorCommand {
                 )
                 .await?;
             }
-            Self::VerifyMerkleTreeRewards { rewards_file } => {
-                verify_merkle_tree_rewards::verify_merkle_tree_rewards(rewards_file).await?;
+            Self::VerifyMerkleTreeRewards { rewards_file, rpc_url } => {
+                verify_merkle_tree_rewards::verify_merkle_tree_rewards(rewards_file, rpc_url).await?;
             }
             #[cfg(feature = "dev")]
             Self::RegisterKey {

--- a/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
+++ b/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
@@ -62,8 +62,8 @@ pub async fn verify_merkle_tree_rewards(rewards_file: String) -> AppResult {
     for (&address, &total_reward) in &noops_list {
         let leaf = generate_merkle_leaf(
             address,
-            rewards.metadata.start_epoch,
-            rewards.metadata.end_epoch,
+            U256::from(rewards.metadata.start_epoch),
+            U256::from(rewards.metadata.end_epoch),
             total_reward,
         );
         leaves.push(leaf);

--- a/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
+++ b/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
@@ -1,0 +1,142 @@
+use colored::Colorize;
+use ethers::types::{Address, U256};
+use ethers::utils::hex;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
+
+use coral_lib::error::{AppError, AppErrorKind, AppResult};
+use coral_lib::structs::merkle_tree::{verify_merkle_proof, MerkleTree};
+use coral_lib::structs::rewards_file::RewardsRawFile;
+use coral_lib::structs::rewards_tree::generate_merkle_leaf;
+use coral_lib::utils::parse::parse_address;
+
+pub async fn verify_merkle_tree_rewards(rewards_file: String) -> AppResult {
+    // open and read rewards file
+    let mut file = File::open(&rewards_file).map_err(|err| {
+        AppError::new(
+            AppErrorKind::OpenFileError,
+            format!("Failed to open rewards file: {}", err),
+        )
+    })?;
+
+    let mut data = String::new();
+    file.read_to_string(&mut data).map_err(|err| {
+        AppError::new(
+            AppErrorKind::ReadFileError,
+            format!("Failed to read rewards file: {}", err),
+        )
+    })?;
+
+    // Deserialize the rewards file
+    let rewards: RewardsRawFile = serde_json::from_str(&data).map_err(|err| {
+        AppError::new(
+            AppErrorKind::ParseError,
+            format!("Failed to parse rewards file: {}", err),
+        )
+    })?;
+
+    // Aggregate total rewards per node operator
+    let mut noops_list: HashMap<Address, U256> = HashMap::new();
+    for (add, operator) in &rewards.node_operators {
+        let address = parse_address(add.to_string()).map_err(|_| {
+            AppError::new(
+                AppErrorKind::ParseError,
+                format!("Invalid address format: {}", add),
+            )
+        })?;
+        let total_rewards_for_operator = U256::from_dec_str(&operator.total).map_err(|_| {
+            AppError::new(
+                AppErrorKind::ParseError,
+                format!("Failed to parse U256 from string: {}", operator.total),
+            )
+        })?;
+
+        let entry = noops_list.entry(address).or_insert_with(U256::zero);
+        *entry += total_rewards_for_operator;
+    }
+
+    // Generate merkle leaves
+    let mut leaves = Vec::new();
+    for (&address, &total_reward) in &noops_list {
+        let leaf = generate_merkle_leaf(
+            address,
+            rewards.metadata.start_epoch,
+            rewards.metadata.end_epoch,
+            total_reward,
+        );
+        leaves.push(leaf);
+    }
+
+    // Generate the Merkle tree and root hash
+    let merkle_tree = MerkleTree::from_leaf_nodes(leaves.clone());
+    let computed_root_hash = merkle_tree.root_hash();
+    let computed_root_hex = hex::encode(computed_root_hash);
+
+    println!(
+        "{}",
+        format!("Computed Merkle root: {}", computed_root_hex).blue()
+    );
+
+    // Compare with merkle root in the file
+    if computed_root_hex.to_lowercase() != rewards.merkle_root.to_lowercase() {
+        return Err(AppError::new(
+            AppErrorKind::MerkleTreeRootInvalid,
+            format!(
+                "Merkle root mismatch: expected {}, found {}",
+                rewards.merkle_root, computed_root_hex
+            ),
+        ));
+    }
+
+    // Verify now each leaf against the merkle root using its proof
+    for (index, leaf) in leaves.iter().enumerate() {
+        let proof = merkle_tree.generate_proof(index);
+        if !verify_merkle_proof(computed_root_hash, *leaf, &proof) {
+            return Err(AppError::new(
+                AppErrorKind::MerkleProofInvalid,
+                format!("Merkle proof verification failed for leaf index {}", index),
+            ));
+        }
+    }
+
+    println!(
+        "{}",
+        "All merkle proofs verified successfully for the given data."
+            .to_string()
+            .green()
+    );
+    println!(
+        "{}",
+        format!("Merkle root matches the provided hash in rewards file {rewards_file}.").green()
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::path::PathBuf;
+    use tokio::runtime::Runtime;
+
+    fn get_base_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    }
+
+    #[test]
+    fn test_verify_merkle_tree_rewards() {
+        let rt = Runtime::new().unwrap();
+
+        let mut test_file_path = get_base_path();
+        test_file_path.push("src/tests/rewards-files/rewards-test-1.json");
+
+        rt.block_on(async {
+            let result =
+                verify_merkle_tree_rewards(test_file_path.to_string_lossy().to_string()).await;
+            println!("verify_merkle_tree_rewards result{:?}", result);
+            assert!(result.is_ok(), "The verification should succeed.");
+        });
+    }
+}

--- a/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
+++ b/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
@@ -184,7 +184,7 @@ mod tests {
 
 
     #[test]
-    fn test_verify_merkle_tree_rewards_ok_3() {
+    fn test_verify_merkle_tree_rewards_ko() {
         let rt = Runtime::new().unwrap();
 
         let sepolia_rpc_url = "https://ethereum-holesky-rpc.publicnode.com";

--- a/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
+++ b/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
@@ -56,8 +56,10 @@ pub async fn verify_merkle_tree_rewards(rewards_file: String, rpc_url: String) -
             )
         })?;
 
+        let total_rewards_gwei = total_rewards_for_operator * U256::exp10(9);
+
         let entry = noops_list.entry(address).or_insert_with(U256::zero);
-        *entry += total_rewards_for_operator;
+        *entry += total_rewards_gwei;
     }
 
     // Generate merkle leaves
@@ -95,6 +97,18 @@ pub async fn verify_merkle_tree_rewards(rewards_file: String, rpc_url: String) -
     // Verify now each leaf against the merkle root using its proof
     for (index, leaf) in leaves.iter().enumerate() {
         let proof = merkle_tree.generate_proof(index);
+        let proof_hex = hex::encode(
+            proof
+                .iter()
+                .flat_map(|x| x.iter())
+                .copied()
+                .collect::<Vec<u8>>(),
+        );
+        println!(
+            "{}",
+            format!("Proof for index {}: {}", index, proof_hex).yellow()
+        );
+
         if !verify_merkle_proof(computed_root_hash, *leaf, &proof) {
             return Err(AppError::new(
                 AppErrorKind::MerkleProofInvalid,

--- a/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
+++ b/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
@@ -9,14 +9,13 @@ use coral_lib::error::{AppError, AppErrorKind, AppResult};
 use coral_lib::structs::merkle_tree::{verify_merkle_proof, MerkleTree};
 use coral_lib::structs::rewards_file::RewardsRawFile;
 use coral_lib::structs::rewards_tree::generate_merkle_leaf;
+use coral_lib::utils::ethereum::{get_provider, is_contract_address};
 use coral_lib::utils::parse::parse_address;
-use coral_lib::utils::ethereum::{is_contract_address, get_provider};
 
 /// Verify the merkle tree rewards data from a given rewards file
 pub async fn verify_merkle_tree_rewards(rewards_file: String, rpc_url: String) -> AppResult {
-
     let provider = get_provider(&rpc_url)?;
-    
+
     // open and read rewards file
     let mut file = File::open(&rewards_file).map_err(|err| {
         AppError::new(
@@ -139,8 +138,11 @@ mod tests {
         test_file_path.push("src/tests/rewards-files/rewards-test-1.json");
 
         rt.block_on(async {
-            let result =
-                verify_merkle_tree_rewards(test_file_path.to_string_lossy().to_string(), sepolia_rpc_url.to_string()).await;
+            let result = verify_merkle_tree_rewards(
+                test_file_path.to_string_lossy().to_string(),
+                sepolia_rpc_url.to_string(),
+            )
+            .await;
             println!("verify_merkle_tree_rewards result {:?}", result);
             assert!(result.is_ok(), "The verification should succeed.");
         });

--- a/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
+++ b/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
@@ -181,4 +181,25 @@ mod tests {
             assert!(result.is_ok(), "The verification should succeed.");
         });
     }
+
+
+    #[test]
+    fn test_verify_merkle_tree_rewards_ok_3() {
+        let rt = Runtime::new().unwrap();
+
+        let sepolia_rpc_url = "https://ethereum-holesky-rpc.publicnode.com";
+
+        let mut test_file_path = get_base_path();
+        test_file_path.push("src/tests/rewards-files/rewards-test-3.json");
+
+        rt.block_on(async {
+            let result = verify_merkle_tree_rewards(
+                test_file_path.to_string_lossy().to_string(),
+                sepolia_rpc_url.to_string(),
+            )
+            .await;
+            println!("verify_merkle_tree_rewards result {:?}", result);
+            assert!(result.is_err(), "The verification should failed, because of the invalid merkle root.");
+        });
+    }
 }

--- a/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
+++ b/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
@@ -182,7 +182,6 @@ mod tests {
         });
     }
 
-
     #[test]
     fn test_verify_merkle_tree_rewards_ko() {
         let rt = Runtime::new().unwrap();
@@ -199,7 +198,10 @@ mod tests {
             )
             .await;
             println!("verify_merkle_tree_rewards result {:?}", result);
-            assert!(result.is_err(), "The verification should failed, because of the invalid merkle root.");
+            assert!(
+                result.is_err(),
+                "The verification should failed, because of the invalid merkle root."
+            );
         });
     }
 }

--- a/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
+++ b/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
@@ -65,8 +65,8 @@ pub async fn verify_merkle_tree_rewards(rewards_file: String, rpc_url: String) -
     for (&address, &total_reward) in &noops_list {
         let leaf = generate_merkle_leaf(
             address,
-            total_reward,
             is_contract_address(&provider, address).await?,
+            total_reward,
         );
         leaves.push(leaf);
     }

--- a/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
+++ b/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
@@ -10,9 +10,13 @@ use coral_lib::structs::merkle_tree::{verify_merkle_proof, MerkleTree};
 use coral_lib::structs::rewards_file::RewardsRawFile;
 use coral_lib::structs::rewards_tree::generate_merkle_leaf;
 use coral_lib::utils::parse::parse_address;
+use coral_lib::utils::ethereum::{is_contract_address, get_provider};
 
 /// Verify the merkle tree rewards data from a given rewards file
-pub async fn verify_merkle_tree_rewards(rewards_file: String) -> AppResult {
+pub async fn verify_merkle_tree_rewards(rewards_file: String, rpc_url: String) -> AppResult {
+
+    let provider = get_provider(&rpc_url)?;
+    
     // open and read rewards file
     let mut file = File::open(&rewards_file).map_err(|err| {
         AppError::new(
@@ -62,9 +66,8 @@ pub async fn verify_merkle_tree_rewards(rewards_file: String) -> AppResult {
     for (&address, &total_reward) in &noops_list {
         let leaf = generate_merkle_leaf(
             address,
-            U256::from(rewards.metadata.start_epoch),
-            U256::from(rewards.metadata.end_epoch),
             total_reward,
+            is_contract_address(&provider, address).await?,
         );
         leaves.push(leaf);
     }
@@ -130,12 +133,14 @@ mod tests {
     fn test_verify_merkle_tree_rewards() {
         let rt = Runtime::new().unwrap();
 
+        let sepolia_rpc_url = "https://ethereum-sepolia-rpc.publicnode.com";
+
         let mut test_file_path = get_base_path();
         test_file_path.push("src/tests/rewards-files/rewards-test-1.json");
 
         rt.block_on(async {
             let result =
-                verify_merkle_tree_rewards(test_file_path.to_string_lossy().to_string()).await;
+                verify_merkle_tree_rewards(test_file_path.to_string_lossy().to_string(), sepolia_rpc_url.to_string()).await;
             println!("verify_merkle_tree_rewards result {:?}", result);
             assert!(result.is_ok(), "The verification should succeed.");
         });

--- a/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
+++ b/coral-cli/src/commands/validator/verify_merkle_tree_rewards.rs
@@ -56,10 +56,10 @@ pub async fn verify_merkle_tree_rewards(rewards_file: String, rpc_url: String) -
             )
         })?;
 
-        let total_rewards_gwei = total_rewards_for_operator * U256::exp10(9);
+        let total_rewards_wei = total_rewards_for_operator * U256::exp10(9);
 
         let entry = noops_list.entry(address).or_insert_with(U256::zero);
-        *entry += total_rewards_gwei;
+        *entry += total_rewards_wei;
     }
 
     // Generate merkle leaves
@@ -143,13 +143,33 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_merkle_tree_rewards() {
+    fn test_verify_merkle_tree_rewards_ok_1() {
         let rt = Runtime::new().unwrap();
 
-        let sepolia_rpc_url = "https://ethereum-sepolia-rpc.publicnode.com";
+        let sepolia_rpc_url = "https://ethereum-holesky-rpc.publicnode.com";
 
         let mut test_file_path = get_base_path();
         test_file_path.push("src/tests/rewards-files/rewards-test-1.json");
+
+        rt.block_on(async {
+            let result = verify_merkle_tree_rewards(
+                test_file_path.to_string_lossy().to_string(),
+                sepolia_rpc_url.to_string(),
+            )
+            .await;
+            println!("verify_merkle_tree_rewards result {:?}", result);
+            assert!(result.is_ok(), "The verification should succeed.");
+        });
+    }
+
+    #[test]
+    fn test_verify_merkle_tree_rewards_ok_2() {
+        let rt = Runtime::new().unwrap();
+
+        let sepolia_rpc_url = "https://ethereum-holesky-rpc.publicnode.com";
+
+        let mut test_file_path = get_base_path();
+        test_file_path.push("src/tests/rewards-files/rewards-test-2.json");
 
         rt.block_on(async {
             let result = verify_merkle_tree_rewards(

--- a/coral-cli/src/tests/rewards-files/rewards-test-1.json
+++ b/coral-cli/src/tests/rewards-files/rewards-test-1.json
@@ -1,0 +1,32 @@
+{
+    "metadata": {
+        "start_epoch": 61180,
+        "end_epoch": 61190,
+        "total_amount": "10000"
+    },
+    "node_operators": {
+        "0xbdadfc936fa42bcc54f39667b1868035290a0241": {
+            "total": "6000",
+            "validator_amounts": [
+                {
+                    "beacon_index": 1685916,
+                    "earned_amount": "6000"
+                }
+            ]
+        },
+        "0xdddeafb492752fc64220ddb3e7c9f1d5cccdfdf0": {
+            "total": "4000",
+            "validator_amounts": [
+                {
+                    "beacon_index": 1685920,
+                    "earned_amount": "1000"
+                },
+                {
+                    "beacon_index": 1685921,
+                    "earned_amount": "3000"
+                }
+            ]
+        }
+    }, 
+    "merkle_root": "3C1F881026060296A023E985F35DEED57E35EBDEA776DA27BF7651C6996BB9EE"
+}

--- a/coral-cli/src/tests/rewards-files/rewards-test-1.json
+++ b/coral-cli/src/tests/rewards-files/rewards-test-1.json
@@ -28,5 +28,5 @@
             ]
         }
     }, 
-    "merkle_root": "3C1F881026060296A023E985F35DEED57E35EBDEA776DA27BF7651C6996BB9EE"
+    "merkle_root": "164fd266b4897088f1548c40c63164ffbb7dab815ff65cee3888fcba59b31343"
 }

--- a/coral-cli/src/tests/rewards-files/rewards-test-1.json
+++ b/coral-cli/src/tests/rewards-files/rewards-test-1.json
@@ -1,32 +1,40 @@
 {
     "metadata": {
-        "start_epoch": 61180,
-        "end_epoch": 61190,
-        "total_amount": "10000"
+        "start_epoch": 76000,
+        "end_epoch": 76225,
+        "total_amount": "38206990"
     },
     "node_operators": {
-        "0xbdadfc936fa42bcc54f39667b1868035290a0241": {
-            "total": "6000",
+        "0x491c56d53b44349937bae9f48716ca6f200b1e6f": {
+            "total": "22927947",
             "validator_amounts": [
                 {
-                    "beacon_index": 1685916,
-                    "earned_amount": "6000"
+                    "beacon_index": 1801279,
+                    "earned_amount": "7641723"
+                },
+                {
+                    "beacon_index": 1801278,
+                    "earned_amount": "7669990"
+                },
+                {
+                    "beacon_index": 1801277,
+                    "earned_amount": "7616234"
                 }
             ]
         },
-        "0xdddeafb492752fc64220ddb3e7c9f1d5cccdfdf0": {
-            "total": "4000",
+        "0x5238edb0e7ec5429b47df68b4deb31b9d85c5229": {
+            "total": "15279043",
             "validator_amounts": [
                 {
-                    "beacon_index": 1685920,
-                    "earned_amount": "1000"
+                    "beacon_index": 1801159,
+                    "earned_amount": "7613536"
                 },
                 {
-                    "beacon_index": 1685921,
-                    "earned_amount": "3000"
+                    "beacon_index": 1801143,
+                    "earned_amount": "7665507"
                 }
             ]
         }
     }, 
-    "merkle_root": "d084a504e90e7784c62925f1bad75bf96caf2c75d6ed28ec0bd5bc4d1b665652"
+    "merkle_root": "91a6110cc06cc538fb97468fbfb9a8a6e2e5b0b874f3a029318496ae53c0f2ae"
 }

--- a/coral-cli/src/tests/rewards-files/rewards-test-1.json
+++ b/coral-cli/src/tests/rewards-files/rewards-test-1.json
@@ -28,5 +28,5 @@
             ]
         }
     }, 
-    "merkle_root": "5a3eff48bb10398e5c094201216a67328999932f656281ec650844b4f1255f73"
+    "merkle_root": "d084a504e90e7784c62925f1bad75bf96caf2c75d6ed28ec0bd5bc4d1b665652"
 }

--- a/coral-cli/src/tests/rewards-files/rewards-test-1.json
+++ b/coral-cli/src/tests/rewards-files/rewards-test-1.json
@@ -28,5 +28,5 @@
             ]
         }
     }, 
-    "merkle_root": "164fd266b4897088f1548c40c63164ffbb7dab815ff65cee3888fcba59b31343"
+    "merkle_root": "5a3eff48bb10398e5c094201216a67328999932f656281ec650844b4f1255f73"
 }

--- a/coral-cli/src/tests/rewards-files/rewards-test-2.json
+++ b/coral-cli/src/tests/rewards-files/rewards-test-2.json
@@ -1,0 +1,53 @@
+{
+    "metadata": {
+        "start_epoch": 76000,
+        "end_epoch": 76225,
+        "total_amount": "61169028"
+    },
+    "node_operators": {
+        "0xdeb533c618e4dc8a16dafea5258668a9caf563e8": {
+            "total": "45849957",
+            "validator_amounts": [
+                {
+                    "beacon_index": 1801253,
+                    "earned_amount": "7651965"
+                },
+                {
+                    "beacon_index": 1801208,
+                    "earned_amount": "7665068"
+                },
+                {
+                    "beacon_index": 1801199,
+                    "earned_amount": "7660677"
+                },
+                {
+                    "beacon_index": 1801190,
+                    "earned_amount": "7629661"
+                },
+                {
+                    "beacon_index": 1801179,
+                    "earned_amount": "7626527"
+                },
+                {
+                    "beacon_index": 1801095,
+                    "earned_amount": "7616059"
+                }
+            ]
+        },
+        "0xdf8febec85593120cfdab2a0132e26b86b6da1c4": {
+            "total": "15319071",
+            "validator_amounts": [
+                {
+                    "beacon_index": 1801187,
+                    "earned_amount": "7658258"
+                },
+                {
+                    "beacon_index": 1801186,
+                    "earned_amount": "7660813"
+                }
+            ]
+        }
+    }, 
+    "merkle_root": "48a5748920d04ebd883ece05768dd3ff819860520019c278b48d7650a5f1b444"
+}
+

--- a/coral-cli/src/tests/rewards-files/rewards-test-3.json
+++ b/coral-cli/src/tests/rewards-files/rewards-test-3.json
@@ -1,0 +1,53 @@
+{
+    "metadata": {
+        "start_epoch": 76000,
+        "end_epoch": 76225,
+        "total_amount": "61169028"
+    },
+    "node_operators": {
+        "0xdeb533c618e4dc8a16dafea5258668a9caf563e8": {
+            "total": "45849957",
+            "validator_amounts": [
+                {
+                    "beacon_index": 1801253,
+                    "earned_amount": "7651965"
+                },
+                {
+                    "beacon_index": 1801208,
+                    "earned_amount": "7665068"
+                },
+                {
+                    "beacon_index": 1801199,
+                    "earned_amount": "7660677"
+                },
+                {
+                    "beacon_index": 1801190,
+                    "earned_amount": "7629661"
+                },
+                {
+                    "beacon_index": 1801179,
+                    "earned_amount": "7626527"
+                },
+                {
+                    "beacon_index": 1801095,
+                    "earned_amount": "7616059"
+                }
+            ]
+        },
+        "0xdf8febec85593120cfdab2a0132e26b86b6da1c4": {
+            "total": "15319071",
+            "validator_amounts": [
+                {
+                    "beacon_index": 1801187,
+                    "earned_amount": "7658258"
+                },
+                {
+                    "beacon_index": 1801186,
+                    "earned_amount": "7660813"
+                }
+            ]
+        }
+    }, 
+    "merkle_root": "0000000000000000000000000"
+}
+

--- a/coral-lib/Cargo.toml
+++ b/coral-lib/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 [dependencies]
 axum = "0.7.5"
 hex = "0.4.3"
+ethers = "2.0.14"
 reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
@@ -20,8 +21,6 @@ url = "2.5.2"
 # Puffer dependencies
 puffersecuresigner = { git = "https://github.com/PufferFinance/secure-signer.git" }
 
-ethers = { version = "2.0.14", optional = true }
-
 [features]
 default = []
-dev = [ "ethers" ]
+dev = []

--- a/coral-lib/src/error/error_kind.rs
+++ b/coral-lib/src/error/error_kind.rs
@@ -11,23 +11,27 @@ pub enum AppErrorKind {
     Io(io::ErrorKind),
 
     AppError,
+    ContractCallError,
     DecodeError,
-    ParseError,
 
     EnvVarError,
 
     EnclaveError,
+    EthersWalletError,
 
-    JsonDeError,
-
-    ContractCallError,
+    JsonDecodeError,
 
     HyperError,
+
+    MerkleProofInvalid,
+    MerkleTreeRootInvalid,
+
+    OpenFileError,
+    ParseError,
+    ReadFileError,
     ReqwestError,
     ServerError,
     SqlError,
-
-    EthersWalletError,
 
     UnknownError,
 }
@@ -46,7 +50,7 @@ impl From<io::Error> for AppErrorKind {
 
 impl From<serde_json::Error> for AppErrorKind {
     fn from(_: serde_json::Error) -> Self {
-        Self::JsonDeError
+        Self::JsonDecodeError
     }
 }
 

--- a/coral-lib/src/error/server_error.rs
+++ b/coral-lib/src/error/server_error.rs
@@ -54,6 +54,7 @@ pub enum ServerErrorCode {
     EvmSendTransactionError,
     EvmWaitForTransactionError,
     EvmMissingTransactionReceipt,
+    EvmGetCodeError,
 
     // db error
     LocalDbConnectionError,

--- a/coral-lib/src/structs/merkle_tree.rs
+++ b/coral-lib/src/structs/merkle_tree.rs
@@ -121,8 +121,18 @@ mod tests {
             .parse()
             .unwrap();
 
-        let leaf1 = generate_merkle_leaf(address1, 61180, 61190, U256::from(6000));
-        let leaf2 = generate_merkle_leaf(address2, 61180, 61190, U256::from(4000));
+        let leaf1 = generate_merkle_leaf(
+            address1,
+            U256::from(61180),
+            U256::from(61190),
+            U256::from(6000),
+        );
+        let leaf2 = generate_merkle_leaf(
+            address2,
+            U256::from(61180),
+            U256::from(61190),
+            U256::from(4000),
+        );
 
         let leaf_nodes = vec![leaf1, leaf2];
         let merkle_tree = MerkleTree::from_leaf_nodes(leaf_nodes.clone());

--- a/coral-lib/src/structs/merkle_tree.rs
+++ b/coral-lib/src/structs/merkle_tree.rs
@@ -1,0 +1,135 @@
+use ethers::abi::AbiEncode;
+use ethers::utils::keccak256;
+
+use std::slice::Iter;
+
+#[derive(Clone, Debug)]
+pub struct MerkleTree {
+    pub layers: Vec<Vec<[u8; 32]>>,
+}
+
+impl MerkleTree {
+    pub fn from_leaf_nodes(mut leaf_nodes: Vec<[u8; 32]>) -> Self {
+        let leaf_nodes_count = leaf_nodes.len();
+
+        let mut full_tree_node_count = 1;
+        // find a power of 2 such that all
+        // leaf nodes can fit into this tree
+        loop {
+            // pad empty leaf nodes with 0x0
+            if full_tree_node_count >= leaf_nodes_count {
+                for _ in 0..(full_tree_node_count - leaf_nodes_count) {
+                    leaf_nodes.push([0; 32]);
+                }
+                break;
+            }
+            full_tree_node_count *= 2;
+        }
+
+        let mut node_stack = leaf_nodes;
+
+        let mut layers = vec![];
+
+        // consolidate until we only have 1 leaf node left
+        while node_stack.len() != 1 {
+            let mut new_node_stack = vec![];
+            for i in (0..node_stack.len()).step_by(2) {
+                let mut left = node_stack[i];
+                let mut right = node_stack[i + 1];
+
+                if right <= left {
+                    std::mem::swap(&mut right, &mut left);
+                }
+                let combined: Vec<u8> = left.iter().chain(right.iter()).copied().collect();
+                new_node_stack.push(keccak256(combined))
+            }
+            layers.push(node_stack);
+            node_stack = new_node_stack;
+        }
+        layers.push(node_stack);
+
+        Self { layers }
+    }
+
+    pub fn leaf_nodes(&self) -> Iter<[u8; 32]> {
+        self.layers[0].iter()
+    }
+
+    pub fn root_hash(&self) -> [u8; 32] {
+        let layer_count = self.layers.len();
+        self.layers[layer_count - 1][0]
+    }
+
+    pub fn generate_proof(&self, leaf_index: usize) -> Vec<[u8; 32]> {
+        let mut merkle_proof = Vec::new();
+
+        let mut curr_index = leaf_index;
+        for layer in &self.layers[..self.layers.len() - 1] {
+            let neighbor_index = if curr_index % 2 == 0 {
+                curr_index + 1
+            } else {
+                curr_index - 1
+            };
+            merkle_proof.push(layer[neighbor_index]);
+            curr_index /= 2;
+        }
+        merkle_proof
+    }
+
+    pub fn print_layers(&self) {
+        for layer in self.layers.iter() {
+            for node in layer.iter() {
+                println!("{}", node.encode_hex());
+            }
+            println!();
+        }
+    }
+}
+
+pub fn verify_merkle_proof(root: [u8; 32], leaf: [u8; 32], proofs: &[[u8; 32]]) -> bool {
+    let computed_root = proofs.iter().fold(leaf, |acc, x| {
+        if acc < *x {
+            let left = acc;
+            let right = x;
+            let combined: Vec<_> = left.iter().chain(right.iter()).copied().collect();
+            keccak256(combined)
+        } else {
+            let left = x;
+            let right = acc;
+            let combined: Vec<_> = left.iter().chain(right.iter()).copied().collect();
+            keccak256(combined)
+        }
+    });
+
+    root == computed_root
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::structs::rewards_tree::generate_merkle_leaf;
+    use ethers::types::{Address, U256};
+    use ethers::utils::hex;
+    #[test]
+    fn test_merkle_tree_and_verify_proof() {
+        let address1: Address = "0xbdadfc936fa42bcc54f39667b1868035290a0241"
+            .parse()
+            .unwrap();
+        let address2: Address = "0xdddeafb492752fc64220ddb3e7c9f1d5cccdfdf0"
+            .parse()
+            .unwrap();
+
+        let leaf1 = generate_merkle_leaf(address1, 61180, 61190, U256::from(6000));
+        let leaf2 = generate_merkle_leaf(address2, 61180, 61190, U256::from(4000));
+
+        let leaf_nodes = vec![leaf1, leaf2];
+        let merkle_tree = MerkleTree::from_leaf_nodes(leaf_nodes.clone());
+
+        let root_hash = merkle_tree.root_hash();
+        println!("Merkle Root: {:?}", hex::encode(root_hash));
+
+        let proof: Vec<[u8; 32]> = merkle_tree.generate_proof(0);
+        println!("Merkle Proof: {:?}", proof);
+        assert!(verify_merkle_proof(root_hash, leaf1, &proof));
+    }
+}

--- a/coral-lib/src/structs/merkle_tree.rs
+++ b/coral-lib/src/structs/merkle_tree.rs
@@ -121,8 +121,8 @@ mod tests {
             .parse()
             .unwrap();
 
-        let leaf1 = generate_merkle_leaf(address1,false, U256::from(6000));
-        let leaf2 = generate_merkle_leaf(address2, true,U256::from(4000));
+        let leaf1 = generate_merkle_leaf(address1, false, U256::from(6000));
+        let leaf2 = generate_merkle_leaf(address2, true, U256::from(4000));
 
         let leaf_nodes = vec![leaf1, leaf2];
         let merkle_tree = MerkleTree::from_leaf_nodes(leaf_nodes.clone());

--- a/coral-lib/src/structs/merkle_tree.rs
+++ b/coral-lib/src/structs/merkle_tree.rs
@@ -121,8 +121,8 @@ mod tests {
             .parse()
             .unwrap();
 
-        let leaf1 = generate_merkle_leaf(address1, U256::from(6000), false);
-        let leaf2 = generate_merkle_leaf(address2, U256::from(4000), true);
+        let leaf1 = generate_merkle_leaf(address1,false, U256::from(6000));
+        let leaf2 = generate_merkle_leaf(address2, true,U256::from(4000));
 
         let leaf_nodes = vec![leaf1, leaf2];
         let merkle_tree = MerkleTree::from_leaf_nodes(leaf_nodes.clone());

--- a/coral-lib/src/structs/merkle_tree.rs
+++ b/coral-lib/src/structs/merkle_tree.rs
@@ -123,15 +123,13 @@ mod tests {
 
         let leaf1 = generate_merkle_leaf(
             address1,
-            U256::from(61180),
-            U256::from(61190),
             U256::from(6000),
+            false
         );
         let leaf2 = generate_merkle_leaf(
             address2,
-            U256::from(61180),
-            U256::from(61190),
             U256::from(4000),
+            true
         );
 
         let leaf_nodes = vec![leaf1, leaf2];

--- a/coral-lib/src/structs/merkle_tree.rs
+++ b/coral-lib/src/structs/merkle_tree.rs
@@ -121,16 +121,8 @@ mod tests {
             .parse()
             .unwrap();
 
-        let leaf1 = generate_merkle_leaf(
-            address1,
-            U256::from(6000),
-            false
-        );
-        let leaf2 = generate_merkle_leaf(
-            address2,
-            U256::from(4000),
-            true
-        );
+        let leaf1 = generate_merkle_leaf(address1, U256::from(6000), false);
+        let leaf2 = generate_merkle_leaf(address2, U256::from(4000), true);
 
         let leaf_nodes = vec![leaf1, leaf2];
         let merkle_tree = MerkleTree::from_leaf_nodes(leaf_nodes.clone());

--- a/coral-lib/src/structs/mod.rs
+++ b/coral-lib/src/structs/mod.rs
@@ -1,1 +1,4 @@
 pub mod eth_types;
+pub mod merkle_tree;
+pub mod rewards_file;
+pub mod rewards_tree;

--- a/coral-lib/src/structs/rewards_file.rs
+++ b/coral-lib/src/structs/rewards_file.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RewardsRawFile {
+    pub metadata: Metadata,
+    pub node_operators: HashMap<String, NodeOperator>,
+    pub merkle_root: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Metadata {
+    pub start_epoch: u64,
+    pub end_epoch: u64,
+    pub total_amount: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct NodeOperator {
+    pub total: String,
+    pub validator_amounts: Vec<ValidatorAmount>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ValidatorAmount {
+    pub beacon_index: u64,
+    pub earned_amount: String,
+}

--- a/coral-lib/src/structs/rewards_tree.rs
+++ b/coral-lib/src/structs/rewards_tree.rs
@@ -1,0 +1,80 @@
+use ethers::abi::Token;
+use ethers::prelude::*;
+use ethers::types::{Address, U256};
+use ethers::utils::keccak256;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct NoOpReward {
+    /// Node operator address from which we calculate the total rewards
+    pub address: Address,
+    /// Total of the rewards for all the validators
+    pub total_rewards: U256,
+}
+
+#[derive(Clone, Debug)]
+pub struct RewardValidatorMerkleData {
+    pub hash: [u8; 32],
+    pub node: Address,
+    pub reward: NoOpReward,
+}
+
+pub fn generate_merkle_leaf(
+    address: Address,
+    start_epoch: u64,
+    end_epoch: u64,
+    total: U256,
+) -> [u8; 32] {
+    let calldata = abi::encode(&[
+        Token::Address(address),
+        Token::Uint(U256::from(start_epoch)),
+        Token::Uint(U256::from(end_epoch)),
+        Token::Uint(total),
+    ]);
+    keccak256(calldata)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::structs::merkle_tree::{verify_merkle_proof, MerkleTree};
+    use ethers::types::U256;
+    use ethers::utils::hex;
+
+    #[test]
+    fn test_merkle_tree_with_rewards() {
+        // Setup rewards data
+        let reward1 = NoOpReward {
+            address: "0xbdadfc936fa42bcc54f39667b1868035290a0241"
+                .parse()
+                .unwrap(),
+            total_rewards: U256::from(5000000),
+        };
+        let reward2 = NoOpReward {
+            address: "0xdddeafb492752fc64220ddb3e7c9f1d5cccdfdf0"
+                .parse()
+                .unwrap(),
+            total_rewards: U256::from(15000000),
+        };
+
+        // Generate merkle leaves
+        let leaf1 = generate_merkle_leaf(reward1.address, 61057, 61179, reward1.total_rewards);
+        let leaf2 = generate_merkle_leaf(reward2.address, 61057, 61179, reward2.total_rewards);
+
+        let leaf_nodes = vec![leaf1, leaf2];
+        let merkle_tree = MerkleTree::from_leaf_nodes(leaf_nodes.clone());
+
+        // Build merkle root and proofs
+        let root_hash = merkle_tree.root_hash();
+        println!("Merkle root: {:?}", hex::encode(root_hash));
+
+        let proof1 = merkle_tree.generate_proof(0);
+        let proof2 = merkle_tree.generate_proof(1);
+        println!("Merkle proof for noop first reward: {:?}", proof1);
+        println!("Merkle proof for noop second reward: {:?}", proof2);
+
+        // Verify proof for every leaf
+        assert!(verify_merkle_proof(root_hash, leaf1, &proof1));
+        assert!(verify_merkle_proof(root_hash, leaf2, &proof2));
+    }
+}

--- a/coral-lib/src/structs/rewards_tree.rs
+++ b/coral-lib/src/structs/rewards_tree.rs
@@ -28,13 +28,13 @@ pub struct RewardValidatorMerkleData {
 /// as explained there https://www.rareskills.io/post/merkle-tree-second-preimage-attack
 /// and to match smart contract function _buildMerkleProof
 pub fn generate_merkle_leaf(address: Address, total: U256, is_l1_contract: bool) -> [u8; 32] {
-	let calldata = abi::encode(&[
-		Token::Address(address),
-		Token::Uint(total),
-		Token::Bool(is_l1_contract),
-	]);
-	let hash = keccak256(calldata);
-	keccak256(hash)
+    let calldata = abi::encode(&[
+        Token::Address(address),
+        Token::Uint(total),
+        Token::Bool(is_l1_contract),
+    ]);
+    let hash = keccak256(calldata);
+    keccak256(hash)
 }
 
 #[cfg(test)]
@@ -60,10 +60,9 @@ mod tests {
             total_rewards: U256::from(15000000),
         };
 
-		// Generate merkle leaves
-		let leaf1 = generate_merkle_leaf(reward1.address, reward1.total_rewards, false);
-		let leaf2 = generate_merkle_leaf(reward2.address, reward1.total_rewards, false);
-
+        // Generate merkle leaves
+        let leaf1 = generate_merkle_leaf(reward1.address, reward1.total_rewards, false);
+        let leaf2 = generate_merkle_leaf(reward2.address, reward1.total_rewards, false);
 
         let leaf_nodes = vec![leaf1, leaf2];
         let merkle_tree = MerkleTree::from_leaf_nodes(leaf_nodes.clone());

--- a/coral-lib/src/structs/rewards_tree.rs
+++ b/coral-lib/src/structs/rewards_tree.rs
@@ -23,15 +23,16 @@ pub struct RewardValidatorMerkleData {
 
 /// Helper to generate merkle tree leaf
 /// With this V3 leaf model
-/// keccak256(abi.encode(noOpAddress, total, isL1Contract))
-/// we double hash to avoid any second preimage attack
+/// The leaf is: keccak256(abi.encode(AliceAddress, isL1Contract, totalETHEarned))
+/// https://github.com/PufferFinance/puffer-contracts/blob/428221065d2405dba94d65ab14f2a7b1ccb054dd/l2-contracts/src/L2RewardManager.sol#L85
+/// Also, we double hash to avoid any second preimage attack
 /// as explained there https://www.rareskills.io/post/merkle-tree-second-preimage-attack
 /// and to match smart contract function _buildMerkleProof
-pub fn generate_merkle_leaf(address: Address, total: U256, is_l1_contract: bool) -> [u8; 32] {
+pub fn generate_merkle_leaf(address: Address, is_l1_contract: bool, total: U256) -> [u8; 32] {
     let calldata = abi::encode(&[
         Token::Address(address),
-        Token::Uint(total),
         Token::Bool(is_l1_contract),
+        Token::Uint(total),
     ]);
     let hash = keccak256(calldata);
     keccak256(hash)
@@ -61,8 +62,8 @@ mod tests {
         };
 
         // Generate merkle leaves
-        let leaf1 = generate_merkle_leaf(reward1.address, reward1.total_rewards, false);
-        let leaf2 = generate_merkle_leaf(reward2.address, reward1.total_rewards, false);
+        let leaf1 = generate_merkle_leaf(reward1.address, false, reward1.total_rewards);
+        let leaf2 = generate_merkle_leaf(reward2.address, false, reward1.total_rewards);
 
         let leaf_nodes = vec![leaf1, leaf2];
         let merkle_tree = MerkleTree::from_leaf_nodes(leaf_nodes.clone());

--- a/coral-lib/src/structs/rewards_tree.rs
+++ b/coral-lib/src/structs/rewards_tree.rs
@@ -22,25 +22,19 @@ pub struct RewardValidatorMerkleData {
 }
 
 /// Helper to generate merkle tree leaf
-/// With this leaf model
-/// keccak256(abi.encode(noopAddress, startEpoch, endEpoch, total))
+/// With this V3 leaf model
+/// keccak256(abi.encode(noOpAddress, total, isL1Contract))
 /// we double hash to avoid any second preimage attack
 /// as explained there https://www.rareskills.io/post/merkle-tree-second-preimage-attack
 /// and to match smart contract function _buildMerkleProof
-pub fn generate_merkle_leaf(
-    address: Address,
-    start_epoch: U256,
-    end_epoch: U256,
-    total: U256,
-) -> [u8; 32] {
-    let calldata = abi::encode(&[
-        Token::Address(address),
-        Token::Uint(start_epoch),
-        Token::Uint(end_epoch),
-        Token::Uint(total),
-    ]);
-    let hash = keccak256(calldata);
-    keccak256(hash)
+pub fn generate_merkle_leaf(address: Address, total: U256, is_l1_contract: bool) -> [u8; 32] {
+	let calldata = abi::encode(&[
+		Token::Address(address),
+		Token::Uint(total),
+		Token::Bool(is_l1_contract),
+	]);
+	let hash = keccak256(calldata);
+	keccak256(hash)
 }
 
 #[cfg(test)]
@@ -66,19 +60,10 @@ mod tests {
             total_rewards: U256::from(15000000),
         };
 
-        // Generate merkle leaves
-        let leaf1 = generate_merkle_leaf(
-            reward1.address,
-            U256::from(61057),
-            U256::from(61179),
-            reward1.total_rewards,
-        );
-        let leaf2 = generate_merkle_leaf(
-            reward2.address,
-            U256::from(61057),
-            U256::from(61179),
-            reward2.total_rewards,
-        );
+		// Generate merkle leaves
+		let leaf1 = generate_merkle_leaf(reward1.address, reward1.total_rewards, false);
+		let leaf2 = generate_merkle_leaf(reward2.address, reward1.total_rewards, false);
+
 
         let leaf_nodes = vec![leaf1, leaf2];
         let merkle_tree = MerkleTree::from_leaf_nodes(leaf_nodes.clone());

--- a/coral-lib/src/utils/ethereum.rs
+++ b/coral-lib/src/utils/ethereum.rs
@@ -131,3 +131,23 @@ pub fn get_transaction_receipt(
         })?;
     Ok(tx)
 }
+
+/// Helper to check if an address is a contract address
+pub async fn is_contract_address<J, E>(
+	provider: &Provider<J>,
+	address: Address,
+) -> AppServerResult<bool>
+where
+	J: JsonRpcClient<Error = E>,
+{
+	let is_contract = provider.get_code(address, None).await.map_err(|err| {
+		let error_msg = "Failed to check if address is a contract address";
+		tracing::error!("{error_msg}: {err}");
+		ServerErrorResponse::new(
+			StatusCode::INTERNAL_SERVER_ERROR,
+			ServerErrorCode::EvmGetCodeError,
+			err.to_string(),
+		)
+	})?;
+	Ok(!is_contract.is_empty())
+}

--- a/coral-lib/src/utils/ethereum.rs
+++ b/coral-lib/src/utils/ethereum.rs
@@ -134,20 +134,20 @@ pub fn get_transaction_receipt(
 
 /// Helper to check if an address is a contract address
 pub async fn is_contract_address<J, E>(
-	provider: &Provider<J>,
-	address: Address,
+    provider: &Provider<J>,
+    address: Address,
 ) -> AppServerResult<bool>
 where
-	J: JsonRpcClient<Error = E>,
+    J: JsonRpcClient<Error = E>,
 {
-	let is_contract = provider.get_code(address, None).await.map_err(|err| {
-		let error_msg = "Failed to check if address is a contract address";
-		tracing::error!("{error_msg}: {err}");
-		ServerErrorResponse::new(
-			StatusCode::INTERNAL_SERVER_ERROR,
-			ServerErrorCode::EvmGetCodeError,
-			err.to_string(),
-		)
-	})?;
-	Ok(!is_contract.is_empty())
+    let is_contract = provider.get_code(address, None).await.map_err(|err| {
+        let error_msg = "Failed to check if address is a contract address";
+        tracing::error!("{error_msg}: {err}");
+        ServerErrorResponse::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            ServerErrorCode::EvmGetCodeError,
+            err.to_string(),
+        )
+    })?;
+    Ok(!is_contract.is_empty())
 }

--- a/coral-lib/src/utils/mod.rs
+++ b/coral-lib/src/utils/mod.rs
@@ -1,8 +1,8 @@
+pub mod ethereum;
 pub mod parse;
 
 #[cfg(feature = "dev")]
 pub mod abi;
-#[cfg(feature = "dev")]
-pub mod ethereum;
+
 #[cfg(feature = "dev")]
 pub mod wallet;

--- a/coral-lib/src/utils/parse.rs
+++ b/coral-lib/src/utils/parse.rs
@@ -1,4 +1,5 @@
 use axum::http::StatusCode;
+use ethers::types::Address;
 
 use crate::{
     error::{AppServerResult, ServerErrorCode, ServerErrorResponse},
@@ -30,4 +31,16 @@ pub fn parse_module_name(module_name: &str) -> AppServerResult<[u8; 32]> {
         )
     })?;
     Ok(module_name)
+}
+
+pub fn parse_address(address: String) -> AppServerResult<Address> {
+    address.parse().map_err(|_err| {
+        let error_msg = format!("Failed to parse address: '{}'", address);
+        tracing::error!("{}", error_msg);
+        ServerErrorResponse::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            ServerErrorCode::ParseError,
+            error_msg,
+        )
+    })
 }


### PR DESCRIPTION
This new sub-command `verify-merkle-tree-rewards` helps any node operator to build the merkle tree in the same way it is done in our close source code repo. 

It builds the merle tree from a json file that is posted publicly everyday, containing rewards list between 2 epochs, for a list of node operators. 

The leaf model we use is the following : 

```
keccak256(abi.encode(alice, startEpoch, endEpoch, total))
```

It compares the merkle root posted on chain, for example in this type of transaction: https://sepolia.etherscan.io/tx/0xbe35b4f6c5f3d4158e14e29b33c6701b0186a4267afad9b45281dd5e78d3c51d#eventlog,  and the one that is generated from the data + 
verify the merkle proofs. 